### PR TITLE
Better Widget Areas

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -75,24 +75,6 @@ function alcatraz_content_width() {
 	$GLOBALS['content_width'] = apply_filters( 'alcatraz_content_width', 640 );
 }
 
-add_action( 'widgets_init', 'alcatraz_widgets_init' );
-/**
- * Register our widget areas.
- *
- * @since  1.0.0
- */
-function alcatraz_widgets_init() {
-	register_sidebar( array(
-		'name'          => esc_html__( 'Sidebar', 'alcatraz' ),
-		'id'            => 'sidebar-1',
-		'description'   => '',
-		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</aside>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
-}
-
 add_action( 'wp_enqueue_scripts', 'alcatraz_scripts' );
 /**
  * Enqueue scripts and styles.
@@ -131,32 +113,37 @@ function alcatraz_scripts() {
 /**
  * Utility functions.
  */
-require ALCATRAZ_PATH . 'inc/utilities.php';
+require_once ALCATRAZ_PATH . 'inc/utilities.php';
 
 /**
  * Custom Header feature.
  */
-require ALCATRAZ_PATH . 'inc/custom-header.php';
+require_once ALCATRAZ_PATH . 'inc/custom-header.php';
 
 /**
  * Custom template tags for this theme.
  */
-require ALCATRAZ_PATH . 'inc/template-tags.php';
+require_once ALCATRAZ_PATH . 'inc/template-tags.php';
+
+/**
+ * Widget Areas.
+ */
+require_once ALCATRAZ_PATH . 'inc/widget-areas.php';
 
 /**
  * Custom functions that act independently of the theme templates.
  */
-require ALCATRAZ_PATH . 'inc/extras.php';
+require_once ALCATRAZ_PATH . 'inc/extras.php';
 
 /**
  * Customizer additions.
  */
-require ALCATRAZ_PATH . 'inc/admin/customizer.php';
+require_once ALCATRAZ_PATH . 'inc/admin/customizer.php';
 
 /**
  * Jetpack compatibility file.
  */
-require ALCATRAZ_PATH . 'inc/jetpack.php';
+require_once ALCATRAZ_PATH . 'inc/jetpack.php';
 
 /**
  * Admin-only functionality.

--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -13,10 +13,21 @@ add_action( 'customize_register', 'alcatraz_customize_register' );
  */
 function alcatraz_customize_register( $wp_customize ) {
 
+	/**
+	 * Modifications to core sections and controls.
+	 */
+
 	// Set some core controls to use postMessage.
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
+
+	// Move the Header Image control into our header section.
+	$wp_customize->get_control( 'header_image' )->section = 'alcatraz_header_section';
+
+	/**
+	 * Alcatraz theme sections.
+	 */
 
 	// Layout section.
 	$wp_customize->add_section(
@@ -27,6 +38,30 @@ function alcatraz_customize_register( $wp_customize ) {
 			'capability' => 'edit_theme_options',
 		)
 	);
+
+	// Header section.
+	$wp_customize->add_section(
+		'alcatraz_header_section',
+		array(
+			'title'      => __( 'Header', 'alcatraz' ),
+			'priority'   => 90,
+			'capability' => 'edit_theme_options',
+		)
+	);
+
+	// Footer section.
+	$wp_customize->add_section(
+		'alcatraz_footer_section',
+		array(
+			'title'      => __( 'Footer', 'alcatraz' ),
+			'priority'   => 140,
+			'capability' => 'edit_theme_options',
+		)
+	);
+
+	/**
+	 * Alcatraz theme controls.
+	 */
 
 	// Page layout.
 	$wp_customize->add_setting(
@@ -40,14 +75,59 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'alcatraz_page_layout_control',
 		array(
-			'type'      => 'radio',
-			'label'     => __( 'Page Layout', 'alcatraz' ),
-			'section'   => 'alcatraz_layout_section',
-			'settings'  => 'alcatraz_options[page_layout]',
-			'choices'   => array(
+			'type'     => 'radio',
+			'label'    => __( 'Page Layout', 'alcatraz' ),
+			'section'  => 'alcatraz_layout_section',
+			'settings' => 'alcatraz_options[page_layout]',
+			'choices'  => array(
 				'full-width'    => __( 'Full Width', 'alcatraz' ),
 				'left-sidebar'  => __( 'Left Sidebar', 'alcatraz' ),
 				'right-sidebar' => __( 'Right Sidebar', 'alcatraz' ),
+			),
+		)
+	);
+
+	// Page Banner widget area.
+	$wp_customize->add_setting(
+		'alcatraz_options[page_banner_widget_area]',
+		array(
+			'default'    => 0,
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
+		)
+	);
+	$wp_customize->add_control(
+		'alcatraz_page_banner_widget_area_control',
+		array(
+			'type'     => 'checkbox',
+			'label'    => __( 'Include Page Banner Widget Area?', 'alcatraz' ),
+			'section'  => 'alcatraz_layout_section',
+			'settings' => 'alcatraz_options[page_banner_widget_area]',
+		)
+	);
+
+	// Number of footer widget areas.
+	$wp_customize->add_setting(
+		'alcatraz_options[footer_widget_areas]',
+		array(
+			'default'    => 3,
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
+		)
+	);
+	$wp_customize->add_control(
+		'alcatraz_footer_widget_areas_control',
+		array(
+			'type'     => 'select',
+			'label'    => __( 'Number of Footer Widget Areas', 'alcatraz' ),
+			'section'  => 'alcatraz_footer_section',
+			'settings' => 'alcatraz_options[footer_widget_areas]',
+			'choices'  => array(
+				0 => __( 'None', 'alcatraz' ),
+				1 => __( '1', 'alcatraz' ),
+				2 => __( '2', 'alcatraz' ),
+				3 => __( '3', 'alcatraz' ),
+				4 => __( '4', 'alcatraz' ),
 			),
 		)
 	);

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -30,6 +30,16 @@ function alcatraz_body_classes( $classes ) {
 		$classes[] = esc_attr( $options['page_layout'] );
 	}
 
+	// Page Banner class.
+	if ( isset( $options['page_banner_widget_area'] ) && $options['page_banner_widget_area'] && is_active_sidebar( 'page-banner' ) ) {
+		$classes[] = 'has-page-banner';
+	}
+
+	// Footer widget areas class.
+	if ( isset( $options['footer_widget_areas'] ) && 0 < (int)$options['footer_widget_areas'] ) {
+		$classes[] = 'footer-widget-areas-' . (int)$options['footer_widget_areas'];
+	}
+
 	// Custom page classes.
 	$custom_page_classes = get_post_meta( $post->ID, '_alcatraz_body_class', true );
 	if ( $custom_page_classes ) {

--- a/inc/widget-areas.php
+++ b/inc/widget-areas.php
@@ -98,7 +98,7 @@ function alcatraz_output_page_banner_widget_area() {
 
 	$options = get_option( 'alcatraz_options' );
 
-	if ( isset( $options['page_banner_widget_area'] ) && (int)$options['page_banner_widget_area'] ) {
+	if ( isset( $options['page_banner_widget_area'] ) && (int)$options['page_banner_widget_area'] && is_active_sidebar( 'page-banner' ) ) {
 		?>
 		<section id="page-banner" class="page-banner page-banner-widget-area widget-area" role="complementary">
 			<?php dynamic_sidebar( 'page-banner' ); ?>

--- a/inc/widget-areas.php
+++ b/inc/widget-areas.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Alcatraz Widget Areas.
+ *
+ * @package alcatraz
+ */
+
+add_action( 'widgets_init', 'alcatraz_register_widget_areas' );
+/**
+ * Register the Alcatraz widget areas.
+ *
+ * @since  1.0.0
+ */
+function alcatraz_register_widget_areas() {
+
+	$options = get_option( 'alcatraz_options' );
+
+	// Primary Sidebar.
+	register_sidebar( array(
+		'name'          => esc_html__( 'Primary Sidebar', 'alcatraz' ),
+		'id'            => 'primary-sidebar',
+		'description'   => __( 'Shows on the left or right side of the page or is hidden based on the "Page Layout" option', 'alcatraz' ),
+		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</aside>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+
+	// Page Banner.
+	if ( isset( $options['page_banner_widget_area'] ) && (int)$options['page_banner_widget_area'] ) {
+		register_sidebar( array(
+			'name'          => esc_html__( 'Page Banner', 'alcatraz' ),
+			'id'            => 'page-banner',
+			'description'   => __( 'Shows on the top of the page in between the menu and the main content area', 'alcatraz' ),
+			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</aside>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
+	}
+
+	// Footer.
+	if ( isset( $options['footer_widget_areas'] ) && 0 < (int)$options['footer_widget_areas'] ) {
+		register_sidebars( (int)$options['footer_widget_areas'], array(
+			'name'          => esc_html__( 'Footer %d', 'alcatraz' ),
+			'id'            => 'footer-widget-area',
+			'description'   => __( 'Shows in the footer', 'alcatraz' ),
+			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</aside>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
+	}
+}
+
+add_action( 'alcatraz_primary_sidebar', 'alcatraz_output_primary_sidebar' );
+/**
+ * Maybe output the Primary Sidebar widget area.
+ *
+ * @since  1.0.0
+ */
+function alcatraz_output_primary_sidebar() {
+
+	global $post;
+
+	$options = get_option( 'alcatraz_options' );
+
+	$page_layout = get_post_meta( $post->ID, '_alcatraz_page_layout', true );
+
+	// Bail if the page layout is set to full-width.
+	if ( $page_layout && 'full-width' === $page_layout ) {
+		return;
+	} elseif ( isset( $options['page_layout'] ) && 'full-width' === $options['page_layout'] ) {
+		return;
+	}
+
+	// Bail if we don't have widgets.
+	if ( ! is_active_sidebar( 'primary-sidebar' ) ) {
+		return;
+	}
+
+	?>
+	<div id="secondary" class="primary-sidebar sidebar widget-area" role="complementary">
+		<?php do_action( 'alcatraz_before_primary_sidebar' ); ?>
+		<?php dynamic_sidebar( 'primary-sidebar' ); ?>
+		<?php do_action( 'alcatraz_after_primary_sidebar' ); ?>
+	</div>
+ 	<?php
+}
+
+add_action( 'alcatraz_after_header', 'alcatraz_output_page_banner_widget_area' );
+/**
+ * Maybe output the Page Banner widget area.
+ *
+ * @since  1.0.0
+ */
+function alcatraz_output_page_banner_widget_area() {
+
+	$options = get_option( 'alcatraz_options' );
+
+	if ( isset( $options['page_banner_widget_area'] ) && (int)$options['page_banner_widget_area'] ) {
+		?>
+		<section id="page-banner" class="page-banner page-banner-widget-area widget-area" role="complementary">
+			<?php dynamic_sidebar( 'page-banner' ); ?>
+		</section>
+		<?php
+	}
+}
+
+add_action( 'alcatraz_before_footer_inside', 'alcatraz_output_footer_widget_areas', 30 );
+/**
+ * Maybe output the Footer widget areas.
+ *
+ * @since  1.0.0
+ */
+function alcatraz_output_footer_widget_areas() {
+
+	$options = get_option( 'alcatraz_options' );
+
+	if ( isset( $options['footer_widget_areas'] ) && 0 < (int)$options['footer_widget_areas'] ) {
+
+		echo '<section id="footer-widget-areas" class="footer-widget-areas">';
+
+		for ( $i = 1; $i <= (int)$options['footer_widget_areas']; $i++ ) {
+
+			// Handle inconsistent -x behavior of register_sidebars.
+			if ( 1 == $i ) {
+				$widget_area_id    = 'footer-widget-area';
+				$widget_area_class = 'footer-widget-area-1';
+			} else {
+				$widget_area_id    = 'footer-widget-area-' . $i;
+				$widget_area_class = $widget_area_id;
+			}
+
+			if ( is_active_sidebar( $widget_area_id ) ) {
+
+				printf(
+					'<div id="%s" class="%s" role="complementary">',
+					$widget_area_class,
+					$widget_area_class . ' footer-widget-area widget-area'
+				);
+
+				dynamic_sidebar( $widget_area_id );
+
+				echo '</div>';
+			}
+		}
+
+		echo '</section>';
+	}
+}

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,15 +1,8 @@
 <?php
 /**
- * Template for the primary sidebar.
+ * Template for the Primary Sidebar widget area.
  *
  * @package alcatraz
  */
 
-if ( ! is_active_sidebar( 'sidebar-1' ) ) {
-	return;
-}
-?>
-
-<div id="secondary" class="widget-area" role="complementary">
-	<?php dynamic_sidebar( 'sidebar-1' ); ?>
-</div>
+do_action( 'alcatraz_primary_sidebar' );


### PR DESCRIPTION
This set of changes makes a few key improvements:
- We have two new theme options, `page_banner_widget_area` and `footer_widget_areas`
- `page_banner_widget_area` is a simple checkbox in the Layout section in the Customizer, and it shows between the menu and the content area
- `footer_widget_areas` is a dropdown with 0-4 as options in the new Footer section in the Customizer, and it registers a variable number of footer widgets that show inside the footer element (in Trestle they show in a separate section above)
- By default the "Custom Header" feature of WordPress adds a section in the Customizer for just that control, so I created a new section Header and moved the header stuff there
- So now we have a Header section and a Footer section and can add to both as needed
- All widget areas are now output on a hook from widget-areas.php
- The Primary Sidebar widget area is now treated the same as other widget areas
- The body gets a class for whether the page banner widget area is set to show and how many footer widget areas are set to show
- The Primary Sidebar widget area does not output at all if the page layout is set to full-width
- There are two new hooks `alcatraz_before_primary_sidebar` and `alcatraz_after_primary_sidebar` for easily adding things above or below the Primary Sidebar widgets

I don't want to go crazy with options, but I think this strikes a nice balance. The potential widget areas that can now be included gives us a flexible base layout, with ways to add custom content just about anywhere. I'm excited.
