### PR TITLE
Add PHP side of new Header Style theme option

### DIFF
--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -108,6 +108,30 @@ function alcatraz_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header style.
+	$wp_customize->add_setting(
+		'alcatraz_options[header_style]',
+		array(
+			'default'    => 'default',
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
+		)
+	);
+	$wp_customize->add_control(
+		'alcatraz_header_style_control',
+		array(
+			'type'     => 'radio',
+			'label'    => __( 'Header Style', 'alcatraz' ),
+			'section'  => 'alcatraz_header_section',
+			'settings' => 'alcatraz_options[header_style]',
+			'choices'  => array(
+				'default' => __( 'Default', 'alcatraz' ),
+				'short'   => __( 'Short', 'alcatraz' ),
+				'side'    => __( 'Side', 'alcatraz' ),
+			),
+		)
+	);
+
 	// Number of footer widget areas.
 	$wp_customize->add_setting(
 		'alcatraz_options[footer_widget_areas]',

--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -21,8 +21,9 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport        = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage';
 
-	// Move the Header Image control into our header section.
-	$wp_customize->get_control( 'header_image' )->section = 'alcatraz_header_section';
+	// Move the Header Image control to the bottom of our header section.
+	$wp_customize->get_control( 'header_image' )->section  = 'alcatraz_header_section';
+	$wp_customize->get_control( 'header_image' )->priority = 120;
 
 	// Disable the Header Text Color control.
 	$wp_customize->remove_control( 'header_textcolor' );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -30,6 +30,11 @@ function alcatraz_body_classes( $classes ) {
 		$classes[] = esc_attr( $options['page_layout'] );
 	}
 
+	// Header style class.
+	if ( isset( $options['header_style'] ) && $options['header_style'] ) {
+		$classes[] = 'header-style-' . esc_attr( $options['header_style'] );
+	}
+
 	// Transparent header class.
 	$transparent_header = get_post_meta( $post->ID, '_alcatraz_transparent_header', true );
 	if ( $transparent_header && 'on' == $transparent_header ) {


### PR DESCRIPTION
This is the PHP side of a new header_style option. It currently has options for default, short, and side, which get added to the body as classes .header-style-default, .header-style-short, and .header-style-side.

With these changes, we can now write the Sass to make the header styles take effect.
