### PR TITLE
Add fix for full-width body class, fixes #14

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -25,8 +25,10 @@ function alcatraz_body_classes( $classes ) {
 	// Page layout class.
 	$page_layout = get_post_meta( $post->ID, '_alcatraz_page_layout', true );
 	if ( $page_layout && 'default' != $page_layout ) {
-		$classes[] = esc_attr( $page_layout );
-	} elseif ( isset( $options['page_layout'] ) ) {
+		if ( 'full-width' != $page_layout ) {
+			$classes[] = esc_attr( $page_layout );
+		}
+	} elseif ( isset( $options['page_layout'] ) && 'full-width' != $options['page_layout'] ) {
 		$classes[] = esc_attr( $options['page_layout'] );
 	}
 


### PR DESCRIPTION
At first I changed the body class to page-full-width, page-left-sidebar, etc. as we discussed, but then I realized we should just assume full-width as default, and in fact in our Sass we were. We weren't referencing full-width as a class at all. This means that we can just have left-sidebar and right-sidebar, and if the page is set to full-width, we output no body class to indicate this, we just assume it in the absence of the sidebar classes.

This paves the way for letting the site layout option use full-width and boxed as its two classes, so we'll end up with full-width, boxed, left-sidebar, and right-sidebar as the body classes that control the main site and page layouts, which feels nice.
