### PR TITLE
Add PHP side of new site_layout option and change full-width page_layout option to no-sidebar

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -38,7 +38,7 @@ function alcatraz_page_options_metabox() {
 		'type'    => 'select',
 		'options' => array(
 			'default'       => __( 'Default', 'alcatraz' ),
-			'full-width'    => __( 'Full Width', 'alcatraz' ),
+			'no-sidebar'    => __( 'No Sidebar', 'alcatraz' ),
 			'left-sidebar'  => __( 'Left Sidebar', 'alcatraz' ),
 			'right-sidebar' => __( 'Right Sidebar', 'alcatraz' ),
 		),

--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -66,6 +66,29 @@ function alcatraz_customize_register( $wp_customize ) {
 	 * Alcatraz theme controls.
 	 */
 
+	// Site layout.
+	$wp_customize->add_setting(
+		'alcatraz_options[site_layout]',
+		array(
+			'default'    => 'full-width',
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
+		)
+	);
+	$wp_customize->add_control(
+		'alcatraz_site_layout_control',
+		array(
+			'type'     => 'radio',
+			'label'    => __( 'Site Layout', 'alcatraz' ),
+			'section'  => 'alcatraz_layout_section',
+			'settings' => 'alcatraz_options[site_layout]',
+			'choices'  => array(
+				'full-width' => __( 'Full Width', 'alcatraz' ),
+				'boxed'      => __( 'Boxed', 'alcatraz' ),
+			),
+		)
+	);
+
 	// Page layout.
 	$wp_customize->add_setting(
 		'alcatraz_options[page_layout]',
@@ -83,7 +106,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'section'  => 'alcatraz_layout_section',
 			'settings' => 'alcatraz_options[page_layout]',
 			'choices'  => array(
-				'full-width'    => __( 'Full Width', 'alcatraz' ),
+				'no-sidebar'    => __( 'No Sidebar', 'alcatraz' ),
 				'left-sidebar'  => __( 'Left Sidebar', 'alcatraz' ),
 				'right-sidebar' => __( 'Right Sidebar', 'alcatraz' ),
 			),

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -22,13 +22,18 @@ function alcatraz_body_classes( $classes ) {
 
 	$options = get_option( 'alcatraz_options' );
 
+	// Site layout class.
+	if ( isset( $options['site_layout'] ) && $options['site_layout'] ) {
+		$classes[] = esc_attr( $options['site_layout'] );
+	}
+
 	// Page layout class.
 	$page_layout = get_post_meta( $post->ID, '_alcatraz_page_layout', true );
 	if ( $page_layout && 'default' != $page_layout ) {
-		if ( 'full-width' != $page_layout ) {
+		if ( 'no-sidebar' != $page_layout ) {
 			$classes[] = esc_attr( $page_layout );
 		}
-	} elseif ( isset( $options['page_layout'] ) && 'full-width' != $options['page_layout'] ) {
+	} elseif ( isset( $options['page_layout'] ) && 'no-sidebar' != $options['page_layout'] ) {
 		$classes[] = esc_attr( $options['page_layout'] );
 	}
 

--- a/inc/widget-areas.php
+++ b/inc/widget-areas.php
@@ -68,9 +68,9 @@ function alcatraz_output_primary_sidebar() {
 	$page_layout = get_post_meta( $post->ID, '_alcatraz_page_layout', true );
 
 	// Bail if the page layout is set to full-width.
-	if ( $page_layout && 'full-width' === $page_layout ) {
+	if ( $page_layout && 'no-sidebar' === $page_layout ) {
 		return;
-	} elseif ( isset( $options['page_layout'] ) && 'full-width' === $options['page_layout'] ) {
+	} elseif ( isset( $options['page_layout'] ) && 'no-sidebar' === $options['page_layout'] ) {
 		return;
 	}
 


### PR DESCRIPTION
This was one of the items in our doc. These changes add a new site_layout theme option, with choices full-width and boxed that get added as classes on the body.

I haven't written the Sass to make the boxed option work yet, and I'm wondering if there is a need for a third option boxed-content, where the page sections would be 100% width but the content inside them would be boxed to a fixed width, vs. true boxed which would simply max-width the entire #page.

I'm also wondering whether we should now rename the page_layout option to primary_sidebar_position or something like that, since now it is only concerned with the alignment/presence of the primary_sidebar. I'll leave that for you to decide.
