### PR TITLE
Fix footer widget areas

### DIFF
--- a/inc/widget-areas.php
+++ b/inc/widget-areas.php
@@ -41,15 +41,30 @@ function alcatraz_register_widget_areas() {
 
 	// Footer.
 	if ( isset( $options['footer_widget_areas'] ) && 0 < (int)$options['footer_widget_areas'] ) {
-		register_sidebars( (int)$options['footer_widget_areas'], array(
-			'name'          => esc_html__( 'Footer %d', 'alcatraz' ),
-			'id'            => 'footer-widget-area',
-			'description'   => __( 'Shows in the footer', 'alcatraz' ),
-			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</aside>',
-			'before_title'  => '<h2 class="widget-title">',
-			'after_title'   => '</h2>',
-		) );
+
+		// Calling register_sidebars to register only one widget area causes problems, so we'll
+		// handle that case separately.
+		if ( 1 == (int)$options['footer_widget_areas'] ) {
+			register_sidebar( array(
+				'name'          => esc_html__( 'Footer', 'alcatraz' ),
+				'id'            => 'footer-widget-area-1',
+				'description'   => __( 'Shows in the footer', 'alcatraz' ),
+				'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+				'after_widget'  => '</aside>',
+				'before_title'  => '<h2 class="widget-title">',
+				'after_title'   => '</h2>',
+			) );
+		} else {
+			register_sidebars( (int)$options['footer_widget_areas'], array(
+				'name'          => esc_html__( 'Footer %d', 'alcatraz' ),
+				'id'            => 'footer-widget-area',
+				'description'   => __( 'Shows in the footer', 'alcatraz' ),
+				'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+				'after_widget'  => '</aside>',
+				'before_title'  => '<h2 class="widget-title">',
+				'after_title'   => '</h2>',
+			) );
+		}
 	}
 }
 
@@ -123,21 +138,14 @@ function alcatraz_output_footer_widget_areas() {
 
 		for ( $i = 1; $i <= (int)$options['footer_widget_areas']; $i++ ) {
 
-			// Handle inconsistent -x behavior of register_sidebars.
-			if ( 1 == $i ) {
-				$widget_area_id    = 'footer-widget-area';
-				$widget_area_class = 'footer-widget-area-1';
-			} else {
-				$widget_area_id    = 'footer-widget-area-' . $i;
-				$widget_area_class = $widget_area_id;
-			}
+			$widget_area_id = 'footer-widget-area-' . $i;
 
 			if ( is_active_sidebar( $widget_area_id ) ) {
 
 				printf(
 					'<div id="%s" class="%s" role="complementary">',
-					$widget_area_class,
-					$widget_area_class . ' footer-widget-area widget-area'
+					$widget_area_id,
+					$widget_area_id . ' footer-widget-area widget-area'
 				);
 
 				dynamic_sidebar( $widget_area_id );


### PR DESCRIPTION
When we added the logic to register the footer widget areas before, we were relying on a function register_sidebars. The typical function you'd use is register_sidebar, and register_sidebars is basically a wrapper function that you can pass a number and the same array of args you pass to register_sidebar. 

The problem with register_sidebars is, since we can only pass one array, how do we specify multiple names and ids? The function supports doing this:

```
register_sidebars( (int)$options['footer_widget_areas'], array(
    'name'          => esc_html__( 'Footer %d', 'alcatraz' ),
    'id'            => 'footer-widget-area',
    'description'   => __( 'Shows in the footer', 'alcatraz' ),
    'before_widget' => '<aside id="%1$s" class="widget %2$s">',
    'after_widget'  => '</aside>',
    'before_title'  => '<h2 class="widget-title">',
    'after_title'   => '</h2>',
) );
```

The %d in the name is supposed to become Footer 1, Footer 2, etc., and it does, but it turns out it doesn't do it when only 1 widget area is being registered. For some reason in that case, it prints "Footer %d".

The other funky thing is that we pass one id, `footer-widget-area`, and these get -x to become `footer-widget-area-1`, `footer-widget-area-2`, etc., but the first one doesn't get it. The first one becomes `footer-widget-area`, then `footer-widget-areas-2`, etc. We were handling this with some extra logic in the widget area output.

But because of the issue with "Footer %d" showing on the screen when only 1 widget area is set to get registered, I decided to check for that situation during the registration, and call the normal register_sidebar when we only want 1 footer widget area. We still call register_sidebars when there are 2+ widget areas to register, because it works great in those situations.

I also took this opportunity to normalize the id of the footer widget area when only 1 is present, so now the id and class added to all footer widget areas are `footer-widget-area-x`. This allowed for simpler logic in the widget area output, as now we can trust that all footer widget area IDs are in the same format. 
