### PR TITLE
Add JS for true live previewing of some Customizer options

### DIFF
--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -197,13 +197,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'label'    => __( 'Mobile Navigation Style', 'alcatraz' ),
 			'section'  => 'alcatraz_header_section',
 			'settings' => 'alcatraz_options[mobile_nav_style]',
-			'choices'  => array(
-				'default'     => __( 'Default', 'alcatraz' ),
-				'slide-left'  => __( 'Slide from Left', 'alcatraz' ),
-				'slide-right' => __( 'Slide from Right', 'alcatraz' ),
-				'full-screen' => __( 'Full Screen', 'alcatraz' ),
-				'fade-in'     => __( 'Fade In', 'alcatraz' ),
-			),
+			'choices'  => alcatraz_get_mobile_nav_style_options( 'mobile-nav-style' ),
 		)
 	);
 

--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -73,6 +73,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'default'    => 'full-width',
 			'type'       => 'option',
 			'capability' => 'edit_theme_options',
+			'transport'  => 'postMessage',
 		)
 	);
 	$wp_customize->add_control(
@@ -140,6 +141,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'default'    => 'default',
 			'type'       => 'option',
 			'capability' => 'edit_theme_options',
+			'transport'  => 'postMessage',
 		)
 	);
 	$wp_customize->add_control(
@@ -164,6 +166,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'default'    => 'button',
 			'type'       => 'option',
 			'capability' => 'edit_theme_options',
+			'transport'  => 'postMessage',
 		)
 	);
 	$wp_customize->add_control(
@@ -173,7 +176,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'label'    => __( 'Mobile Navigation Toggle Style', 'alcatraz' ),
 			'section'  => 'alcatraz_header_section',
 			'settings' => 'alcatraz_options[mobile_nav_toggle_style]',
-			'choices'  => alcatraz_get_mobile_nav_toggle_options( 'header' ),
+			'choices'  => alcatraz_get_mobile_nav_toggle_options( 'mobile-nav-toggle-style' ),
 		)
 	);
 
@@ -184,6 +187,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'default'    => 'default',
 			'type'       => 'option',
 			'capability' => 'edit_theme_options',
+			'transport'  => 'postMessage',
 		)
 	);
 	$wp_customize->add_control(
@@ -194,9 +198,9 @@ function alcatraz_customize_register( $wp_customize ) {
 			'section'  => 'alcatraz_header_section',
 			'settings' => 'alcatraz_options[mobile_nav_style]',
 			'choices'  => array(
-				'default' => __( 'Default', 'alcatraz' ),
-				'from-left' => __( 'Slide from Left', 'alcatraz' ),
-				'from-right' => __( 'Slide from Right', 'alcatraz' ),
+				'default'     => __( 'Default', 'alcatraz' ),
+				'slide-left'  => __( 'Slide from Left', 'alcatraz' ),
+				'slide-right' => __( 'Slide from Right', 'alcatraz' ),
 				'full-screen' => __( 'Full Screen', 'alcatraz' ),
 				'fade-in'     => __( 'Fade In', 'alcatraz' ),
 			),
@@ -210,7 +214,7 @@ function alcatraz_customize_register( $wp_customize ) {
 			'default'    =>  '',
 			'type'       => 'option',
 			'capability' => 'edit_theme_options'
-			)
+		)
 	);
 	$wp_customize->add_control(
 		new WP_Customize_Media_Control( $wp_customize, 'alcatraz_logo',
@@ -298,7 +302,7 @@ function alcatraz_customize_preview_js() {
 		'alcatraz_customizer',
 		ALCATRAZ_URL . 'js/customizer.js',
 		array( 'customize-preview' ),
-		ALCATRAZ_VERSION,
+		'1.1.0',
 		true
 	);
 }

--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -296,7 +296,7 @@ function alcatraz_customize_preview_js() {
 		'alcatraz_customizer',
 		ALCATRAZ_URL . 'js/customizer.js',
 		array( 'customize-preview' ),
-		'1.1.0',
+		ALCATRAZ_VERSION,
 		true
 	);
 }

--- a/inc/choices.php
+++ b/inc/choices.php
@@ -26,18 +26,42 @@ function alcatraz_get_text_colors( $context = '' ) {
 }
 
 /**
- * Return an array of mobile menu navigation style options.
+ * Return an array of mobile nav toggle style options.
  *
  * @since   1.0.0
  *
- * @return  array
+ * @param   string  $context  The context to pass to our filter.
+ *
+ * @return  array             The array of options.
  */
 function alcatraz_get_mobile_nav_toggle_options( $context = '' ) {
 
-	$mobile_nav_options = array(
+	$mobile_nav_toggle_styles = array(
 		'button'    => __( 'Button', 'alcatraz' ),
 		'hamburger' => __( 'Hamburger', 'alcatraz' ),
 	);
 
-	return apply_filters( 'alcatraz_mobile_nav_toggle_options', $mobile_nav_options, $context );
+	return apply_filters( 'alcatraz_mobile_nav_toggle_options', $mobile_nav_toggle_styles, $context );
+}
+
+/**
+ * Return an array of mobile nav style options.
+ *
+ * @since   1.0.0
+ *
+ * @param   string  $context  The context to pass to our filter.
+ *
+ * @return  array             The array of options.
+ */
+function alcatraz_get_mobile_nav_style_options( $context = '' ) {
+
+	$mobile_nav_styles = array(
+		'default'     => __( 'Default', 'alcatraz' ),
+		'slide-left'  => __( 'Slide from Left', 'alcatraz' ),
+		'slide-right' => __( 'Slide from Right', 'alcatraz' ),
+		'full-screen' => __( 'Full Screen', 'alcatraz' ),
+		'fade-in'     => __( 'Fade In', 'alcatraz' ),
+	);
+
+	return apply_filters( 'alcatraz_mobile_nav_style_options', $mobile_nav_styles, $context );
 }

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -4,18 +4,52 @@
 
 ( function( $ ) {
 
+	var $body = $( 'body' );
+
 	// Handle live previewing for the site title.
 	wp.customize( 'blogname', function( value ) {
 		value.bind( function( to ) {
 			$( '.site-title a' ).text( to );
-		} );
-	} );
+		});
+	});
 
 	// Handle live previewing for the site description.
 	wp.customize( 'blogdescription', function( value ) {
 		value.bind( function( to ) {
 			$( '.site-description' ).text( to );
-		} );
-	} );
+		});
+	});
 
-} )( jQuery );
+	// Handle live previewing for the site layout.
+	wp.customize( 'alcatraz_options[site_layout]', function( value ) {
+		value.bind( function( to ) {
+			$body.removeClass( 'full-width boxed boxed-content' );
+			$body.addClass( to );
+		});
+	});
+
+	// Handle live previewing for the header style.
+	wp.customize( 'alcatraz_options[header_style]', function( value ) {
+		value.bind( function( to ) {
+			$body.removeClass( 'header-style-default header-style-short header-style-side' );
+			$body.addClass( 'header-style-' + to );
+		});
+	});
+
+	// Handle live previewing for the mobile nav toggle style.
+	wp.customize( 'alcatraz_options[mobile_nav_toggle_style]', function( value ) {
+		value.bind( function( to ) {
+			$body.removeClass( 'mobile-nav-toggle-style-hamburger mobile-nav-toggle-style-button' );
+			$body.addClass( 'mobile-nav-toggle-style-' + to );
+		});
+	});
+
+	// Handle live previewing for the mobile nav style.
+	wp.customize( 'alcatraz_options[mobile_nav_style]', function( value ) {
+		value.bind( function( to ) {
+			$body.removeClass( 'mobile-nav-style-default mobile-nav-style-slide-left mobile-nav-style-slide-right mobile-nav-style-full-screen mobile-nav-style-fade-in' );
+			$body.addClass( 'mobile-nav-style-' + to );
+		});
+	});
+
+})( jQuery );


### PR DESCRIPTION
This PR adds the JS and other necessary changes to support true live previewing of some of our Customizer options via `'transport' => 'postMessage'`. I say some because this PR only addresses the theme options that we achieve with only a body class. Other options like the Page Banner Widget Area, Footer Widget Areas, and Page Layout will still require the refresh transport method because the DOM is fundamentally changed in several ways when those options are changed.

I think we can also achieve live previewing using postMessage on our logo options and possibly on the Footer Bottom option, but these are a bit more involved so I'd prefer to submit additional PRs for these.
