### PR TITLE
Add empty theme options page

### DIFF
--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -5,8 +5,19 @@
  * @package alcatraz
  */
 
+// Include our theme options page.
+require_once ALCATRAZ_PATH . 'inc/admin/options-page.php';
+
 // Include CMB2.
 require_once ALCATRAZ_PATH . 'lib/cmb2/init.php';
+
+/**
+ * Initialize our options page class.
+ *
+ * @since  1.0.0
+ */
+$options_page = new Alcatraz_Options_Page();
+$options_page->init();
 
 add_action( 'cmb2_admin_init', 'alcatraz_page_options_metabox' );
 /**

--- a/inc/admin/options-page.php
+++ b/inc/admin/options-page.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Alcatraz options page class.
+ *
+ * @package alcatraz
+ *
+ * @since   1.0.0
+ */
+
+class Alcatraz_Options_Page {
+
+	/**
+	 * Our theme options.
+	 *
+	 * @since  1.0.0
+	 */
+	private $options;
+
+	/**
+	 * The constructor.
+	 *
+	 * @since  1.0.0
+	 */
+	public function __construct() {
+		$this->options = get_option( 'alcatraz_options' );
+	}
+
+	/**
+	 * Setup our hooks.
+	 *
+	 * @since  1.0.0
+	 */
+	public function init() {
+		add_action( 'admin_menu', array( $this, 'register_options_page' ) );
+	}
+
+	/**
+	 * Register our options page.
+	 *
+	 * @since  1.0.0
+	 */
+	public function register_options_page() {
+		add_menu_page(
+			__( 'Alcatraz Theme Options', 'alcatraz' ),
+			__( 'Theme Options', 'alcatraz' ),
+			'manage_options',
+			'alcatraz_options_page',
+			array(
+				$this,
+				'options_page'
+			)
+		);
+	}
+
+	/**
+	 * Output our theme options page.
+	 *
+	 * @since  1.0.0
+	 */
+	public function  options_page() {
+		?>
+		<div class="wrap alcatraz-options-page">
+			<h1><?php _e( 'Alcatraz Theme Options', 'alcatraz' ) ?></h1>
+			<form method="post" action="options.php">
+				<?php submit_button(); ?>
+			</form>
+		</div>
+		<?php
+	}
+}

--- a/inc/admin/options-page.php
+++ b/inc/admin/options-page.php
@@ -57,7 +57,7 @@ class Alcatraz_Options_Page {
 	 *
 	 * @since  1.0.0
 	 */
-	public function  options_page() {
+	public function options_page() {
 		?>
 		<div class="wrap alcatraz-options-page">
 			<h1><?php _e( 'Alcatraz Theme Options', 'alcatraz' ) ?></h1>


### PR DESCRIPTION
This gives us the start of a Theme Options page. Currently all that I'm outputting on the page is a submit button, but we're ready to add settings_fields() and do_settings_sections() and any options we want on this page.

Right now the menu link is at the very bottom. We could move it anywhere. Jordan and I were discussing and I think because it's the kind of thing that you set once initially it belongs near the bottom, but having it under Appearance would move it closer to other related things, so I'm open to your thoughts.
