### PR TITLE
Populate option defaults on theme activation for better NUX

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,9 +9,44 @@ define( 'ALCATRAZ_VERSION', '1.0.0' );
 define( 'ALCATRAZ_PATH', trailingslashit( get_template_directory() ) );
 define( 'ALCATRAZ_URL', trailingslashit( get_template_directory_uri() ) );
 
+add_action( 'after_switch_theme', 'alcatraz_first_setup' );
+/**
+ * Check for our theme options and set defaults for any options that don't already exist.
+ *
+ * This only runs one time right after the user activates the theme.
+ *
+ * @since  1.0.0
+ */
+function alcatraz_first_setup() {
+
+	// Look for existing options.
+	$options = get_option( 'alcatraz_options' );
+
+	if ( ! $options ) {
+		$options = array();
+	}
+
+	$defaults = alcatraz_get_option_defaults();
+
+	// Bail early if the existing options match the defaults.
+	if ( $options === $defaults ) {
+		return;
+	}
+
+	// Populate any defaults that are missing.
+	foreach ( $defaults as $key => $value ) {
+		if ( ! array_key_exists( $key, $options ) ) {
+			$options[ $key ] = $value;
+		}
+	}
+
+	// Update options with defaults.
+	update_option( 'alcatraz_options', $options, 'yes' );
+}
+
 add_action( 'after_setup_theme', 'alcatraz_setup' );
 /**
- * Set up theme defaults and register support for various WordPress features.
+ * Load translations and register support for various WordPress features.
  *
  * @since  1.0.0
  */

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -2,6 +2,8 @@
 /**
  * Alcatraz admin-only functionality.
  *
+ * Everything in this file is only run if is_admin() is true.
+ *
  * @package alcatraz
  */
 

--- a/inc/admin/customizer.php
+++ b/inc/admin/customizer.php
@@ -14,6 +14,11 @@ add_action( 'customize_register', 'alcatraz_customize_register' );
 function alcatraz_customize_register( $wp_customize ) {
 
 	/**
+	 * Get the default values for our options.
+	 */
+	$option_defaults = alcatraz_get_option_defaults();
+
+	/**
 	 * Modifications to core sections and controls.
 	 */
 
@@ -70,7 +75,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[site_layout]',
 		array(
-			'default'           => 'full-width',
+			'default'           => $option_defaults['site_layout'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'sanitize_text_field',
@@ -96,7 +101,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[page_layout]',
 		array(
-			'default'           => 'right-sidebar',
+			'default'           => $option_defaults['page_layout'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'sanitize_text_field',
@@ -121,10 +126,10 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[page_banner_widget_area]',
 		array(
-			'default'           => 0,
+			'default'           => $option_defaults['page_banner_widget_area'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
-			'sanitize_callback' => 'intval',
+			'sanitize_callback' => 'absint',
 		)
 	);
 	$wp_customize->add_control(
@@ -141,7 +146,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[header_style]',
 		array(
-			'default'           => 'default',
+			'default'           => $option_defaults['header_style'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'sanitize_text_field',
@@ -167,7 +172,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[mobile_nav_toggle_style]',
 		array(
-			'default'           => 'button',
+			'default'           => $option_defaults['mobile_nav_toggle_style'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'sanitize_text_field',
@@ -189,7 +194,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[mobile_nav_style]',
 		array(
-			'default'           => 'default',
+			'default'           => $option_defaults['mobile_nav_style'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'sanitize_text_field',
@@ -211,7 +216,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[sub_menu_toggle_style]',
 		array(
-			'default'           => '',
+			'default'           => $option_defaults['sub_menu_toggle_style'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'sanitize_text_field',
@@ -233,7 +238,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[logo_id]',
 		array(
-			'default'           => '',
+			'default'           => $option_defaults['logo_id'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'alcatraz_empty_or_int',
@@ -253,7 +258,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[mobile_logo_id]',
 		array(
-			'default'           => '',
+			'default'           => $option_defaults['mobile_logo_id'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'alcatraz_empty_or_int',
@@ -273,7 +278,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[footer_widget_areas]',
 		array(
-			'default'           => 3,
+			'default'           => $option_defaults['footer_widget_areas'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'intval',
@@ -300,7 +305,7 @@ function alcatraz_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'alcatraz_options[footer_bottom]',
 		array(
-			'default'           => '',
+			'default'           => $option_defaults['footer_bottom'],
 			'type'              => 'option',
 			'capability'        => 'edit_theme_options',
 			'sanitize_callback' => 'wp_kses_post',

--- a/inc/choices.php
+++ b/inc/choices.php
@@ -6,6 +6,32 @@
  */
 
 /**
+ * Return an array of the default theme options.
+ *
+ * @since   1.0.0
+ *
+ * @return  array
+ */
+function alcatraz_get_option_defaults() {
+
+	$defaults = array(
+		'site_layout'             => 'full-width',
+		'page_layout'             => 'right-sidebar',
+		'page_banner_widget_area' => 0,
+		'header_style'            => 'default',
+		'mobile_nav_toggle_style' => 'hamburger',
+		'mobile_nav_style'        => 'default',
+		'sub_menu_toggle_style'   => 'chevron',
+		'logo_id'                 => '',
+		'mobile_logo_id'          => '',
+		'footer_widget_areas'     => 3,
+		'footer_bottom'           => '',
+	);
+
+	return apply_filters( 'alcatraz_option_defaults', $defaults );
+}
+
+/**
  * Return an array of text color classes and display names.
  *
  * @since   1.0.0


### PR DESCRIPTION
After spinning up another Alcatraz test site I decided to fix our first install problem.

Previously our theme options weren't getting default values until the user hit the Customizer for the first time, because our option definitions were all happening as part of our Customizer setting registration.

This PR uses the `after_switch_theme` hook, which fires only once right after theme activation, to check for our `alcatraz_options` option and populate any default values that are missing. Any values that are already set will not get overwritten, only missing values will get set to the default values.

This PR also introduces a function `alcatraz_get_option_defaults()` to be the single place where default option value definitions live, and naturally an `alcatraz_option_defaults` filter that can be used to manipulate the default option values from a child theme or plugin.

This PR also then uses the `alcatraz_get_option_defaults()` function in the Customizer, so that we don't end up defining default option values in multiple places.

This PR also fixes an issue with using `intval` as the `sanitize_callback` in the Customizer. This was my bad as I told Jordan specifically to use it. It turns out that `intval()` in PHP takes a second argument for the 'base', and WordPress passes something as the second value to the `sanitize_callback` callbacks, which can cause bad things in certain situations. There is a WordPress function `absint` that seems to be the recommended thing to use, so I've switched to using that here.

Now we've got much better NUX. :)
