### PR TITLE
Fix the broken-looking default nav upon theme activation

### DIFF
--- a/header.php
+++ b/header.php
@@ -38,6 +38,8 @@
 
 		</div>
 
+		<?php if ( has_nav_menu( 'primary' ) ) : ?>
+
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<div class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">
 				<span class="menu-text"><?php esc_html_e( 'Menu', 'alcatraz' ); ?></span>
@@ -51,6 +53,8 @@
 			<div id="mobile-nav-left-swipe-zone"></div>
 			<div id="mobile-nav-right-swipe-zone"></div>
 		</nav>
+
+		<?php endif; ?>
 
 		<?php do_action( 'alcatraz_after_header_inside' ); ?>
 


### PR DESCRIPTION
Sometimes the simplest solution is the best. I'm open to other ideas, but by simply checking whether we had a menu in our primary location before calling wp_nav_menu, we only output a menu if the user has specifically saved one in our location, which means our custom wrap class will always be there and the styling will be good.

This does mean that when the user first activates the theme they won't see a primary menu. I think that rather than just picking one of their menus and calling it the primary we should solve that problem by having a big admin notice that appears upon first activation and says "Welcome to Alcatraz, here are links to documentation and guides, to get started do 1. Set up a nav menu, 2. Visit the Customizer, ...". That first activation experience is a key moment where the user is evaluating the theme, so I think having something that calls right out to them and makes it clear what do to next is a good idea.

I'll add a line in our todo list to revisit this as part of a broader NUX push.
