### PR TITLE
Turn the custom-background feature off by default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -102,13 +102,15 @@ function alcatraz_setup() {
 	) );
 
 	// Enable the custom background feature.
-	add_theme_support(
-		'custom-background',
-		apply_filters( 'alcatraz_custom_background_args', array(
-			'default-color' => 'ffffff',
-			'default-image' => '',
-		) )
-	);
+	if ( apply_filters( 'alcatraz_enable_custom_background', false ) ) {
+		add_theme_support(
+			'custom-background',
+			apply_filters( 'alcatraz_custom_background_args', array(
+				'default-color' => 'ffffff',
+				'default-image' => '',
+			) )
+		);
+	}
 }
 
 add_action( 'after_setup_theme', 'alcatraz_content_width', 0 );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -54,7 +54,7 @@ function alcatraz_body_classes( $classes ) {
 
 	// Sub-menu toggle style class.
 	if ( isset( $options['sub_menu_toggle_style'] ) && $options['sub_menu_toggle_style'] ) {
-		$classes[] = 'sub-menu-toggle-style-' . esc_attr($options['sub_menu_toggle_style'] );
+		$classes[] = 'sub-menu-toggle-style-' . esc_attr( $options['sub_menu_toggle_style'] );
 	}
 
 	// Transparent header class.


### PR DESCRIPTION
Previously we've had a Colors section in the Customizer but only a single color in it, background-color. This isn't very useful without other colors, and since we've decided to not have any colors in the Customizer, I went ahead and gave it the same treatment as post_formats. We turn it off by default but provide a filter to turn it back on.

This has the added benefit of keeping the Colors section in the Customizer registered, but because there aren't any controls registered to the section it doesn't show at all. Unregistering it could be bad for plugin compatibility, as some some plugins might add colors to it for whatever reason, but hiding it in this way allows us to get rid of an entire section in the Customizer and reduce our option count by one.
