### PR TITLE
Add activation notice and ajax handler for dismissing it and reorganize theme options

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -253,7 +253,7 @@ require_once ALCATRAZ_PATH . 'inc/ajax.php';
 require_once ALCATRAZ_PATH . 'inc/template-tags.php';
 
 /**
- * Option choices.
+ * Theme options.
  */
 require_once ALCATRAZ_PATH . 'inc/theme-options.php';
 

--- a/functions.php
+++ b/functions.php
@@ -44,7 +44,7 @@ function alcatraz_first_setup() {
 	update_option( 'alcatraz_options', $options, 'yes' );
 }
 
-add_action( 'after_setup_theme', 'alcatraz_setup' );
+add_action( 'after_setup_theme', 'alcatraz_setup', 0 );
 /**
  * Load translations and register support for various WordPress features.
  *
@@ -177,7 +177,7 @@ function alcatraz_scripts() {
 	// Skip link focus fix JS.
 	wp_register_script(
 		'alcatraz-skip-link-focus-fix',
-		ALCATRAZ_URL . 'js/skip-link-focus-fix.js',
+		ALCATRAZ_URL . 'js/src/skip-link-focus-fix.js',
 		array(),
 		ALCATRAZ_VERSION,
 		true
@@ -195,7 +195,7 @@ function alcatraz_scripts() {
 	// Navigation JS.
 	wp_register_script(
 		'alcatraz-navigation',
-		ALCATRAZ_URL . 'js/navigation.js',
+		ALCATRAZ_URL . 'js/src/navigation.js',
 		array( 'jquery', 'alcatraz-jquery-mobile' ),
 		ALCATRAZ_VERSION,
 		true
@@ -243,14 +243,19 @@ function alcatraz_init_bfa() {
 require_once ALCATRAZ_PATH . 'inc/utilities.php';
 
 /**
- * Option choices.
+ * Ajax callbacks.
  */
-require_once ALCATRAZ_PATH . 'inc/choices.php';
+require_once ALCATRAZ_PATH . 'inc/ajax.php';
 
 /**
  * Custom template tags for this theme.
  */
 require_once ALCATRAZ_PATH . 'inc/template-tags.php';
+
+/**
+ * Option choices.
+ */
+require_once ALCATRAZ_PATH . 'inc/theme-options.php';
 
 /**
  * Theme hook output.

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -65,7 +65,7 @@ function alcatraz_activation_notice() {
 		);
 
 		$documentation_link = sprintf(
-			'<a href="%s">%s</a>',
+			'<a href="%s" target="_blank">%s</a>',
 			'https://github.com/carrieforde/Alcatraz/wiki',
 			__( 'Alcatraz documentation on Github', 'alcatraz' )
 		);

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -21,6 +21,66 @@ require_once ALCATRAZ_PATH . 'lib/cmb2/init.php';
 $options_page = new Alcatraz_Options_Page();
 $options_page->init();
 
+add_action( 'admin_enqueue_scripts', 'alcatraz_admin_enqueue_scripts' );
+/**
+ * Enqueue our admin JS.
+ *
+ * @since  1.0.0
+ *
+ * @param  string  $hook  The page being displayed.
+ */
+function alcatraz_admin_enqueue_scripts( $hook ) {
+
+	wp_enqueue_script(
+		'alcatraz-admin-scripts',
+		ALCATRAZ_URL . 'js/alcatraz-admin.js',
+		array( 'jquery' ),
+		ALCATRAZ_VERSION,
+		true
+	);
+}
+
+add_action( 'admin_notices', 'alcatraz_activation_notice' );
+/**
+ * Show an admin notice on initial activation.
+ *
+ * @since  1.0.0
+ */
+function alcatraz_activation_notice() {
+
+	$options = get_option( 'alcatraz_options' );
+
+	if ( $options['show_activation_notice'] ) {
+
+		$customizer_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( admin_url( 'customize.php' ) ),
+			__( 'Customizer', 'alcatraz' )
+		);
+
+		$options_page_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( admin_url( 'admin.php?page=alcatraz_options_page' ) ),
+			__( 'Options Page', 'alcatraz' )
+		);
+
+		$documentation_link = sprintf(
+			'<a href="%s">%s</a>',
+			'https://github.com/carrieforde/Alcatraz/wiki',
+			__( 'Alcatraz documentation on Github', 'alcatraz' )
+		);
+
+		?>
+		<div id="alcatraz-activation-notice" class="updated notice is-dismissible" style="padding-bottom: 5px;">
+			<h2><?php _e( 'Welcome to Alcatraz', 'alcatraz' ); ?></h2>
+			<p><?php _e( 'Get started by configuring visual options in the', 'alcatraz' ); ?> <?php echo $customizer_link; ?></p>
+			<p><?php _e( 'All non-visual options can be found on the', 'alcatraz' ); ?> <?php echo $options_page_link; ?></p>
+			<p><?php _e( 'For development resources visit the', 'alcatraz' ); ?> <?php echo $documentation_link; ?></p>
+		</div>
+		<?php
+	}
+}
+
 add_action( 'admin_init', 'alcatraz_add_editor_styles' );
 /**
  * Include our theme CSS in the TinyMCE editor.

--- a/inc/admin/admin.php
+++ b/inc/admin/admin.php
@@ -42,7 +42,7 @@ function alcatraz_admin_enqueue_scripts( $hook ) {
 
 add_action( 'admin_notices', 'alcatraz_activation_notice' );
 /**
- * Show an admin notice on initial activation.
+ * Show an activation notice.
  *
  * @since  1.0.0
  */

--- a/inc/admin/options-page.php
+++ b/inc/admin/options-page.php
@@ -78,7 +78,7 @@ class Alcatraz_Options_Page {
 		register_setting(
 			'alcatraz_options',
 			'alcatraz_options',
-			array( $this, 'alcatraz_validate_options' )
+			array( $this, 'validate_options' )
 		);
 
 		add_settings_section(
@@ -189,68 +189,15 @@ class Alcatraz_Options_Page {
 	/**
 	 * Validate our options before saving.
 	 *
-	 * Because we're storing all of our options under a single key, we need
-	 * to also validate our Customizer options here, which allows us to avoid
-	 * having to specify sanitize_callback functions in our customizer.php file.
+	 * @since   1.0.0
 	 *
-	 * @since  1.0.0
+	 * @param   array  $input  The options to update.
+	 *
+	 * @return  array          The updated options.
 	 */
-	public function alcatraz_validate_options( $input ) {
+	public function validate_options( $input ) {
 
-		// Start with any existing options.
-		$options = get_option( 'alcatraz_options' );
-
-		// Update options on the options page.
-		if ( ! empty( $input['facebook_url'] ) ) {
-			$options['facebook_url']  = sanitize_text_field( $input['facebook_url'] );
-		}
-		if ( ! empty( $input['twitter_url'] ) ) {
-			$options['twitter_url']   = sanitize_text_field( $input['twitter_url'] );
-		}
-		if ( ! empty( $input['instagram_url'] ) ) {
-			$options['instagram_url'] = sanitize_text_field( $input['instagram_url'] );
-		}
-		if ( ! empty( $input['pinterest_url'] ) ) {
-			$options['pinterest_url'] = sanitize_text_field( $input['pinterest_url'] );
-		}
-		if ( ! empty( $input['youtube_url'] ) ) {
-			$options['youtube_url']   = sanitize_text_field( $input['youtube_url'] );
-		}
-
-		// Update options in the Customizer.
-		if ( ! empty( $input['site_layout'] ) ) {
-			$options['site_layout'] = sanitize_text_field( $input['site_layout'] );
-		}
-		if ( ! empty( $input['page_layout'] ) ) {
-			$options['page_layout'] = sanitize_text_field( $input['page_layout'] );
-		}
-		if ( ! empty( $input['page_banner_widget_area'] ) ) {
-			$options['page_banner_widget_area'] = absint( $input['page_banner_widget_area'] );
-		}
-		if ( ! empty( $input['header_style'] ) ) {
-			$options['header_style'] = sanitize_text_field( $input['header_style'] );
-		}
-		if ( ! empty( $input['mobile_nav_toggle_style'] ) ) {
-			$options['mobile_nav_toggle_style'] = sanitize_text_field( $input['mobile_nav_toggle_style'] );
-		}
-		if ( ! empty( $input['mobile_nav_style'] ) ) {
-			$options['mobile_nav_style'] = sanitize_text_field( $input['mobile_nav_style'] );
-		}
-		if ( ! empty( $input['sub_menu_toggle_style'] ) ) {
-			$options['sub_menu_toggle_style'] = sanitize_text_field( $input['sub_menu_toggle_style'] );
-		}
-		if ( ! empty( $input['logo_id'] ) ) {
-			$options['logo_id'] = alcatraz_empty_or_int( $input['logo_id'] );
-		}
-		if ( ! empty( $input['mobile_logo_id'] ) ) {
-			$options['mobile_logo_id'] = alcatraz_empty_or_int( $input['mobile_logo_id'] );
-		}
-		if ( ! empty( $input['footer_widget_areas'] ) ) {
-			$options['footer_widget_areas'] = absint( $input['footer_widget_areas'] );
-		}
-		if ( ! empty( $input['footer_bottom'] ) ) {
-			$options['footer_bottom'] = sanitize_text_field( $input['footer_bottom'] );
-		}
+		$options = alcatraz_validate_options( $input );
 
 		return $options;
 	}

--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Alcatraz Ajax.
+ *
+ * @package alcatraz
+ */
+
+add_action( 'wp_ajax_alcatraz_hide_activation_notice', 'alcatraz_hide_admin_notice' );
+/**
+ * Ajax handler for hiding the admin notice.
+ *
+ * @since  1.0.0
+ */
+function alcatraz_hide_admin_notice() {
+
+	$options = get_option( 'alcatraz_options' );
+
+	$options['show_activation_notice'] = 0;
+
+	update_option( 'alcatraz_options', $options, true );
+
+	wp_die();
+}

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Alcatraz option choices.
+ * Alcatraz Theme Options.
  *
  * @package alcatraz
  */
@@ -15,6 +15,7 @@
 function alcatraz_get_option_defaults() {
 
 	$defaults = array(
+		'show_activation_notice'  => 1,
 		'site_layout'             => 'full-width',
 		'page_layout'             => 'right-sidebar',
 		'page_banner_widget_area' => 0,
@@ -34,6 +35,83 @@ function alcatraz_get_option_defaults() {
 	);
 
 	return apply_filters( 'alcatraz_option_defaults', $defaults );
+}
+
+/**
+ * Validate our theme options.
+ *
+ * This function serves as the one and only place for all option validation.
+ * Other functions that need to validate options should call this function.
+ *
+ * @since   1.0.0
+ *
+ * @param   array  $input  The options to update.
+ *
+ * @return  array          The updated options.
+ */
+function alcatraz_validate_options( $input ) {
+
+	// Start with any existing options.
+	$options = get_option( 'alcatraz_options' );
+
+	// Update options on the options page.
+	if ( isset( $input['facebook_url'] ) ) {
+		$options['facebook_url']  = sanitize_text_field( $input['facebook_url'] );
+	}
+	if ( isset( $input['twitter_url'] ) ) {
+		$options['twitter_url']   = sanitize_text_field( $input['twitter_url'] );
+	}
+	if ( isset( $input['instagram_url'] ) ) {
+		$options['instagram_url'] = sanitize_text_field( $input['instagram_url'] );
+	}
+	if ( isset( $input['pinterest_url'] ) ) {
+		$options['pinterest_url'] = sanitize_text_field( $input['pinterest_url'] );
+	}
+	if ( isset( $input['youtube_url'] ) ) {
+		$options['youtube_url']   = sanitize_text_field( $input['youtube_url'] );
+	}
+
+	// Update options in the Customizer.
+	if ( isset( $input['site_layout'] ) ) {
+		$options['site_layout'] = sanitize_text_field( $input['site_layout'] );
+	}
+	if ( isset( $input['page_layout'] ) ) {
+		$options['page_layout'] = sanitize_text_field( $input['page_layout'] );
+	}
+	if ( isset( $input['page_banner_widget_area'] ) ) {
+		$options['page_banner_widget_area'] = absint( $input['page_banner_widget_area'] );
+	}
+	if ( isset( $input['header_style'] ) ) {
+		$options['header_style'] = sanitize_text_field( $input['header_style'] );
+	}
+	if ( isset( $input['mobile_nav_toggle_style'] ) ) {
+		$options['mobile_nav_toggle_style'] = sanitize_text_field( $input['mobile_nav_toggle_style'] );
+	}
+	if ( isset( $input['mobile_nav_style'] ) ) {
+		$options['mobile_nav_style'] = sanitize_text_field( $input['mobile_nav_style'] );
+	}
+	if ( isset( $input['sub_menu_toggle_style'] ) ) {
+		$options['sub_menu_toggle_style'] = sanitize_text_field( $input['sub_menu_toggle_style'] );
+	}
+	if ( isset( $input['logo_id'] ) ) {
+		$options['logo_id'] = alcatraz_empty_or_int( $input['logo_id'] );
+	}
+	if ( isset( $input['mobile_logo_id'] ) ) {
+		$options['mobile_logo_id'] = alcatraz_empty_or_int( $input['mobile_logo_id'] );
+	}
+	if ( isset( $input['footer_widget_areas'] ) ) {
+		$options['footer_widget_areas'] = absint( $input['footer_widget_areas'] );
+	}
+	if ( isset( $input['footer_bottom'] ) ) {
+		$options['footer_bottom'] = sanitize_text_field( $input['footer_bottom'] );
+	}
+
+	// Update any options saved via Ajax.
+	if ( isset( $input['show_activation_notice'] ) ) {
+		$options['show_activation_notice'] = $input['show_activation_notice'];
+	}
+
+	return $options;
 }
 
 /**

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -108,7 +108,7 @@ function alcatraz_validate_options( $input ) {
 
 	// Update any options saved via Ajax.
 	if ( isset( $input['show_activation_notice'] ) ) {
-		$options['show_activation_notice'] = $input['show_activation_notice'];
+		$options['show_activation_notice'] = absint( $input['show_activation_notice'] );
 	}
 
 	return $options;

--- a/js/alcatraz-admin.js
+++ b/js/alcatraz-admin.js
@@ -1,0 +1,20 @@
+/**
+ * Alcatraz Admin JS.
+ */
+
+( function( $ ) {
+
+	$( document ).ready( function() {
+
+		$( '#alcatraz-activation-notice .notice-dismiss' ).on( 'click', function() {
+			var data = {
+				'action': 'alcatraz_hide_activation_notice',
+			};
+
+			$.post( ajaxurl, data, function( response ) {
+				// Silence is golden.
+			});
+		});
+	});
+
+})( jQuery );


### PR DESCRIPTION
This is another one of those PRs that started as one thing and became more. :)

My first goal was to add an activation notice (technically an "admin notice") that would show right after the user first activates the theme. Normally in WordPress admin notices can be made dismissible simply by including the class `is-dismissible` on the notice wrapper, but the default behavior is for this to be remembered per-user. This means that if I'm developing a site for a client and I dismiss a notice, the client will still see that notice when they log in on their own account until they dismiss it themselves. I don't like this behavior, so in one of my plugins I had added an Ajax handler that would trigger when the close icon was clicked and save an option in the database that would remember that the admin notice had been dismissed, resulting in an admin notice that would never been seen again after it had been first dismissed (unless the option was reset). I brought an improved version of that logic into Alcatraz, and now we have a truly dismissible activation notice:

![Image of Alcatraz activation notice](http://files.braadmartin.com/alcatraz-activation-notice.png)

The language is definitely not final. I knew that I wanted a link to the Customizer, the options page, and our documentation, but beyond that I didn't spend too much time on the exact wording. Let's discuss it and keep making it as awesome as we can.

When I got to the point of being ready to add the Ajax handler, I needed a place to put it. At first I put it in the admin.php file, because it's a back end thing, but this wasn't working because before we include admin.php we check `is_admin()`, and that check returns false for Ajax requests. I thought about it and I think we'll end up doing more things with Ajax before we hit 1.0.0, so I created a new file inside /inc called `ajax.php`. Currently this file only contains the Ajax handler for saving the fact that the activation notice has been dismissed.

I also needed an admin JS file to hook up the listener for clicking on the close icon, so I added another new file inside /js called `alcatraz-admin.js`. The enqueue happens inside admin.php because in this case the is_admin check is the perfect check. I decided not to hook this file up to our JS minification grunt task for now, because it's not nearly as critical that we minimize JS and CSS on the back end, but I'll probably hook it up to our jshint task at some point.

At that point I had all the logic set up but when I dismissed the notice it wasn't saving. I used `alcatraz_log()` to inspect the values of the options being saved, and I found 2 issues. First, our options page class that contained our validation function was only initialized from admin.php, which was only included if `is_admin()` was true, and this meant that we could only ever count on our validation function running if an admin screen was actually being displayed, which was not true on Ajax requests. Second, in our validation function we were using `if ( ! empty( $thing ) )`, and it turns out that `empty()` counts `false` and therefore `0` as empty, which was preventing us from saving `false` or `0` as any option values.

The solution for the first issue was to move our option validation function out of our `Alcatraz_Options_Page` class. It never felt right to me that it lived in that class anyways, and having it outside of our `is_admin()` check allows it to be used in any context. I moved it into a new function `alcatraz_validate_options()` in `choices.php` and then renamed that file `theme-options.php`, then in our options page class I simply did this:

``` php
/**
 * Validate our options before saving.
 *
 * @since   1.0.0
 *
 * @param   array  $input  The options to update.
 *
 * @return  array          The updated options.
 */
public function validate_options( $input ) {
    $options = alcatraz_validate_options( $input );
    return $options;
}
```

This is much more flexible. Now anytime we need to validate any option we can just call `alcatraz_validate_options()` and we don't have to worry about whether our options page class has been initialized.

The solution for the second problem was to switch to using `isset()` instead of `empty()`. The `isset()` check is more appropriate here conceptually because we're just trying to confirm that the key exists on the array, and the only reason I was using `empty()` is because I wanted to avoid saving an empty value (but of course I didn't realize false is considered any empty value).

Here are a few other changes in this PR:
- Consistent priorities for all of our functions hooked on `after_setup_theme` (now all are at 0)
- Fixing of the paths for the non-concatenated versions of our JS files
- Rename our `alcatraz_validate_options` method inside our `Alcatraz_Options_Page` class to just `validate_options`

With all these changes we now have a pretty sweet activation notice, a better file structure, and everything is in place for adding new Ajax things while staying organized. :)
