### PR TITLE
Use more consistent calls to get_template_part and remove widgets from the 404 template

### DIFF
--- a/404.php
+++ b/404.php
@@ -21,36 +21,9 @@ get_header(); ?>
 				</header>
 
 				<div class="page-content">
-					<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'alcatraz' ); ?></p>
+					<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try a search?', 'alcatraz' ); ?></p>
 
 					<?php get_search_form(); ?>
-
-					<?php the_widget( 'WP_Widget_Recent_Posts' ); ?>
-
-					<?php if ( alcatraz_categorized_blog() ) : // Only show the widget if site has multiple categories. ?>
-					<div class="widget widget_categories">
-						<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'alcatraz' ); ?></h2>
-						<ul>
-						<?php
-							wp_list_categories( array(
-								'orderby'    => 'count',
-								'order'      => 'DESC',
-								'show_count' => 1,
-								'title_li'   => '',
-								'number'     => 10,
-							) );
-						?>
-						</ul>
-					</div>
-					<?php endif; ?>
-
-					<?php
-						$archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'alcatraz' ), convert_smilies( ':)' ) ) . '</p>';
-						the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$archive_content" );
-					?>
-
-					<?php the_widget( 'WP_Widget_Tag_Cloud' ); ?>
-
 				</div>
 			</section>
 

--- a/archive.php
+++ b/archive.php
@@ -26,11 +26,7 @@ get_header(); ?>
 
 			<?php while ( have_posts() ) : the_post(); ?>
 
-				<?php
-					// Get the template based on the post type from a child theme if it's there,
-					// otherwise use ours.
-					get_template_part( 'template-parts/content', get_post_type() );
-				?>
+				<?php get_template_part( 'template-parts/content', get_post_type() ); ?>
 
 			<?php endwhile; ?>
 

--- a/search.php
+++ b/search.php
@@ -23,10 +23,7 @@ get_header(); ?>
 
 			<?php while ( have_posts() ) : the_post(); ?>
 
-				<?php
-					// Get the template from a child theme if it's there, otherwise use ours.
-					get_template_part( 'template-parts/content', 'search' );
-				?>
+				<?php get_template_part( 'template-parts/content', 'search' ); ?>
 
 			<?php endwhile; ?>
 

--- a/single.php
+++ b/single.php
@@ -17,13 +17,7 @@ get_header(); ?>
 
 		<?php while ( have_posts() ) : the_post(); ?>
 
-			<?php $post_type = get_post_type();
-
-			if ( 'post' == $post_type ) {
-				$post_type = '';
-			}
-
-			get_template_part( 'template-parts/content-single', $post_type ); ?>
+			<?php get_template_part( 'template-parts/content-single', get_post_type() ); ?>
 
 			<?php the_post_navigation(); ?>
 


### PR DESCRIPTION
I realized we were doing something a bit silly in single.php by specifically emptying the $post_type variable before we called get_template_part() if the post type was just 'post'. I think this was done to ensure that content-single.php was the template that matched, but after some testing I found that this would be the template that matches anyways, so passing the post type always was just a way to allow content-single.php to truly be a default single post template, and now you can override the template used for the single pages of the post type 'post' separately with a `content-single-post.php` template.

After making this change I went through our other top level templates and made them more consistent when they call get_template_part(), and I ripped a bunch of stuff out of 404.php that I was surprised to see, like calls to specific widgets that may or may not be styled or used.

I actually found the issue with our get_template_part call in single.php while writing new documentation on our template system, which can be found [here](https://github.com/carrieforde/Alcatraz/wiki/Template-System)
