### PR TITLE
Filter social networks

### DIFF
--- a/inc/admin/classes/class-options-page.php
+++ b/inc/admin/classes/class-options-page.php
@@ -100,17 +100,21 @@ class Alcatraz_Options_Page {
 			)
 		);
 
-		add_settings_field(
-			'facebook_url',
-			__( 'Facebook', 'alcatraz' ),
-			array( $this, 'field_text' ),
-			'alcatraz_settings_section',
-			'alcatraz_options_page_settings',
-			array(
-				'id'          => 'facebook_url',
-				'description' => __( 'Enter your Facebook profile URL', 'alcatraz' ),
-			)
-		);
+
+	$networks = alcatraz_get_social_networks();
+		foreach( $networks as $network => $network_data ) {
+			add_settings_field(
+				$network_data->id,
+				$network_data->label,
+				array( $this, 'field_text' ),
+					'alcatraz_settings_section',
+					'alcatraz_options_page_settings',
+				array(
+					'id'          => $network_data->id,
+					'description' => $network_data->description,
+				)
+			);
+		}
 
 		add_settings_field(
 			'twitter_url',

--- a/inc/admin/classes/class-options-page.php
+++ b/inc/admin/classes/class-options-page.php
@@ -88,81 +88,21 @@ class Alcatraz_Options_Page {
 			'alcatraz_settings_section'
 		);
 
-		add_settings_field(
-			'email_url',
-			__( 'Email', 'alcatraz' ),
-			array( $this, 'field_text' ),
-				'alcatraz_settings_section',
-				'alcatraz_options_page_settings',
-			array(
-				'id'          => 'email_url',
-				'description' => __( 'Enter your email address', 'alcatraz' ),
-			)
-		);
-
-
 	$networks = alcatraz_get_social_networks();
-		foreach( $networks as $network => $network_data ) {
+
+	foreach ( $networks as $network => $network_data ) {
 			add_settings_field(
-				$network_data->id,
-				$network_data->label,
-				array( $this, 'field_text' ),
-					'alcatraz_settings_section',
-					'alcatraz_options_page_settings',
-				array(
-					'id'          => $network_data->id,
-					'description' => $network_data->description,
-				)
-			);
+		        $network . '_url',
+		        $network_data['display_name'],
+		        array( $this, 'field_text' ),
+		        'alcatraz_settings_section',
+		        'alcatraz_options_page_settings',
+		        array(
+		            'id'          => $network . '_url',
+		            'description' => $network_data['description'],
+		        )
+		    );
 		}
-
-		add_settings_field(
-			'twitter_url',
-			__( 'Twitter', 'alcatraz' ),
-			array( $this, 'field_text' ),
-			'alcatraz_settings_section',
-			'alcatraz_options_page_settings',
-			array(
-				'id'          => 'twitter_url',
-				'description' => __( 'Enter your Twitter profile URL', 'alcatraz' ),
-			)
-		);
-
-		add_settings_field(
-			'instagram_url',
-			__( 'Instagram', 'alcatraz' ),
-			array( $this, 'field_text' ),
-			'alcatraz_settings_section',
-			'alcatraz_options_page_settings',
-			array(
-				'id'          => 'instagram_url',
-				'description' => __( 'Enter your Instagram profile URL', 'alcatraz' ),
-			)
-		);
-
-		add_settings_field(
-			'pinterest_url',
-			__( 'Pinterest', 'alcatraz' ),
-			array( $this, 'field_text' ),
-			'alcatraz_settings_section',
-			'alcatraz_options_page_settings',
-			array(
-				'id'          => 'pinterest_url',
-				'description' => __( 'Enter your Pinterest profile URL', 'alcatraz' ),
-			)
-		);
-
-		add_settings_field(
-			'youtube_url',
-			__( 'Youtube', 'alcatraz' ),
-			array( $this, 'field_text' ),
-			'alcatraz_settings_section',
-			'alcatraz_options_page_settings',
-			array(
-				'id'          => 'youtube_url',
-				'description' => __( 'Enter your You Tube channel URL', 'alcatraz' ),
-			)
-		);
 	}
 
 	/**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -192,6 +192,51 @@ function alcatraz_category_transient_flusher() {
 }
 
 /**
+ * Return an array of the social network data.
+ *
+ * @since   1.0.0
+ *
+ * @return  array
+ */
+function alcatraz_get_social_networks( $context = '' ) {
+
+	$networks = array(
+		'email' => array(
+			'display_name' => __( 'Email', 'alcatraz' ),
+			'description'  => __( 'Enter your email address', 'alcatraz' ),
+			'icon'         => 'envelope',
+		),
+		'facebook' => array(
+			'display_name' => __( 'Facebook', 'alcatraz' ),
+			'description'  => __( 'Enter your Facebook url', 'alcatraz' ),
+			'icon'         => 'facebook',
+		),
+		'twitter' => array(
+			'display_name' => __( 'Twitter', 'alcatraz' ),
+			'description'  => __( 'Enter your Twitter url', 'alcatraz' ),
+			'icon'         => 'twitter',
+		),
+		'instagram' => array(
+			'display_name' => __( 'Instagram', 'alcatraz' ),
+			'description'  => __( 'Enter your Instagram url', 'alcatraz' ),
+			'icon'         => 'instagram',
+		),
+		'pinterest' => array(
+			'display_name' => __( 'Pinterest', 'alcatraz' ),
+			'description'  => __( 'Enter your Pinterest url', 'alcatraz' ),
+			'icon'         => 'twitter',
+		),
+		'youtube' => array(
+			'display_name' => __( 'Youtube', 'alcatraz' ),
+			'description'  => __( 'Enter your Youtube url', 'alcatraz' ),
+			'icon'         => 'youtube',
+		),
+	);
+
+	return apply_filters( 'alcatraz_social_networks', $networks, $context );
+}
+
+/**
  * Build and return the social network icon HTML.
  *
  * @since   1.0.0
@@ -200,59 +245,66 @@ function alcatraz_category_transient_flusher() {
  */
 function alcatraz_get_the_social_network_icons() {
 
-	$options = get_option( 'alcatraz_options' );
+	$options  = get_option( 'alcatraz_options' );
+	$networks = alcatraz_get_social_networks();
 
 	ob_start(); ?>
 
 	<div class="alcatraz-social-icon-wrap">
-		<ul class="alcatraz-social-icons">
-			<?php if ( ! empty( $options['email_url'] ) ) : ?>
-				<li class="email">
-					<a href="mailto:<?php echo esc_attr( $options['email_url'] ) ; ?>" class="alcatraz-social-icon alcatraz-icon-email" target="_blank">
-						<i class="fa fa-envelope"></i>
-					</a>
-				</li>
-			<?php endif; ?>
-			<?php if ( ! empty( $options['facebook_url'] ) ) : ?>
-				<li class="facebook">
-					<a href="<?php echo esc_url( $options['facebook_url'] ) ; ?>" class="alcatraz-social-icon alcatraz-icon-facebook" target="_blank">
-						<i class="fa fa-facebook"></i>
-					</a>
-				</li>
-			<?php endif; ?>
-			<?php if ( ! empty( $options['twitter_url'] ) ) : ?>
-				<li class="twitter">
-					<a href="<?php echo esc_url( $options['twitter_url'] ) ; ?>" class="alcatraz-social-icon alcatraz-icon-twitter" target="_blank">
-						<i class="fa fa-twitter"></i>
-					</a>
-				</li>
-			<?php endif; ?>
-			<?php if ( ! empty( $options['instagram_url'] ) ) : ?>
-				<li class="instagram">
-					<a href="<?php echo esc_url( $options['instagram_url'] ) ; ?>" class="alcatraz-social-icon alcatraz-icon-instagram" target="_blank">
-						<i class="fa fa-instagram"></i>
-					</a>
-				</li>
-			<?php endif; ?>
-			<?php if ( ! empty( $options['pinterest_url'] ) ) : ?>
-				<li class="pinterest">
-					<a href="<?php echo esc_url( $options['pinterest_url'] ) ; ?>" class="alcatraz-social-icon alcatraz-icon-pinterest" target="_blank">
-						<i class="fa fa-pinterest"></i>
-					</a>
-				</li>
-			<?php endif; ?>
-			<?php if ( ! empty( $options['youtube_url'] ) ) : ?>
-				<li class="youtube">
-					<a href="<?php echo esc_url( $options['youtube_url'] ) ; ?>" class="alcatraz-social-icon alcatraz-icon-youtube" target="_blank">
-						<i class="fa fa-youtube"></i>
-					</a>
-				</li>
-			<?php endif; ?>
-		</ul>
+	    <ul class="alcatraz-social-icons">
+	        <?php foreach ( $networks as $network => $network_data ) {
+	            if ( ! empty( $options[ $network . '_url' ] ) ) {
+	                 echo alcatraz_get_social_network_icon_html( $network, $options[ $network . '_url' ], $network_data );
+	            }
+	        } ?>
+	    </ul>
 	</div>
+
 	<?php
 
-	return apply_filters( 'alcatraz_social_network_icons', ob_get_clean(), $options );
+	return apply_filters( 'alcatraz_social_network_icons', ob_get_clean(), $options, $networks );
+}
+
+/**
+ * Build and return the HTML for a single social icon.
+ *
+ * @since   1.0.0
+ *
+ * @param   string  $network       The network name.
+ * @param   string  $url           The network URL.
+ * @param   array   $network_data  The array of network data.
+ *
+ * @return  string                 The HTML for the social icon.
+ */
+function alcatraz_get_social_network_icon_html( $network, $url, $network_data = array() ) {
+
+    // Bail if we don't have a network.
+    if ( empty( $network ) ) {
+        return;
+    }
+
+    // Use mailto: links for any network URLs that are email addresses.
+    if ( is_email( $url ) ) {
+        $url = 'mailto:' . $url;
+    }
+
+    // Use an icon if it is there, otherwise output the network name.
+    if ( isset( $network_data['icon'] ) ) {
+        $icon_classes = apply_filters( 'alcatraz_social_icon_classes', 'fa fa-' . $network_data['icon'], $network, $url, $network_data );
+        $icon = '<i class="' . esc_attr( $icon_classes ) . '" /></i>';
+    } else {
+        $icon = esc_html( $network );
+    }
+
+    $icon_html = sprintf(
+        '<li class="%s"><a href="%s" class="%s" target="_blank">%s</a></li>',
+        esc_attr( $network ),
+        esc_url( $url ),
+        'alcatraz-social-icon alcatraz-icon-' . esc_attr( $network ),
+        $icon
+    );
+
+    return apply_filters( 'alcatraz_social_icon_html', $icon_html, $network, $url, $network_data );
 }
 
 /**

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -28,44 +28,17 @@ function alcatraz_get_option_defaults() {
 		'mobile_logo_id'          => '',
 		'footer_widget_areas'     => 3,
 		'footer_bottom'           => '',
-		'email_url'               => '',
-		'facebook_url'            => '',
-		'twitter_url'             => '',
-		'instagram_url'           => '',
-		'pinterest_url'           => '',
-		'youtube_url'             => '',
 		'social_icons_in_footer'  => '',
 	);
 
+	$networks = alcatraz_get_social_networks();
+
+	 // Loop over any social networks and default the network URLs to empty string.
+	 foreach ( $networks as $network => $network_data ) {
+	     $defaults[ $network . '_url' ] = '';
+	 }
+
 	return apply_filters( 'alcatraz_option_defaults', $defaults );
-}
-
-
-/**
- * Return an array of the social network data.
- *
- * @since   1.0.0
- *
- * @return  array
- */
-function alcatraz_get_social_networks() {
-
-	$networks = array(
-		'Facebook' => array(
-			'label'       => __( 'Facebook', 'alcatraz' ),
-			'id'          => 'facebook_url',
-			'description' => __( 'sdfsdfg', 'alcatraz' ),
-			'icon'        => '',
-		),
-		'Github' => array(
-			'label'       => __( 'Github', 'alcatraz' ),
-			'id'          => 'github_url',
-			'description' => __( 'sdfsdfg', 'alcatraz' ),
-			'icon'        => '',
-		),
-	);
-
-	return apply_filters( 'alcatraz_social_networks', $networks );
 }
 
 /**
@@ -85,24 +58,13 @@ function alcatraz_validate_options( $input ) {
 	// Start with any existing options.
 	$options = get_option( 'alcatraz_options' );
 
+	$networks = alcatraz_get_social_networks();
+
 	// Update options on the options page.
-	if ( isset( $input['email_url'] ) ) {
-		$options['email_url'] = sanitize_text_field( $input['email_url'] );
-	}
-	if ( isset( $input['facebook_url'] ) ) {
-		$options['facebook_url'] = sanitize_text_field( $input['facebook_url'] );
-	}
-	if ( isset( $input['twitter_url'] ) ) {
-		$options['twitter_url'] = sanitize_text_field( $input['twitter_url'] );
-	}
-	if ( isset( $input['instagram_url'] ) ) {
-		$options['instagram_url'] = sanitize_text_field( $input['instagram_url'] );
-	}
-	if ( isset( $input['pinterest_url'] ) ) {
-		$options['pinterest_url'] = sanitize_text_field( $input['pinterest_url'] );
-	}
-	if ( isset( $input['youtube_url'] ) ) {
-		$options['youtube_url'] = sanitize_text_field( $input['youtube_url'] );
+	foreach ( $networks as $network => $network_data ) {
+		if ( isset( $input[ $network . '_url' ] ) ) {
+	    	$options[ $network . '_url' ] = sanitize_text_field( $input[ $network . '_url' ] );
+	    }
 	}
 
 	// Update options in the Customizer.

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -40,6 +40,34 @@ function alcatraz_get_option_defaults() {
 	return apply_filters( 'alcatraz_option_defaults', $defaults );
 }
 
+
+/**
+ * Return an array of the social network data.
+ *
+ * @since   1.0.0
+ *
+ * @return  array
+ */
+function alcatraz_get_social_networks() {
+
+	$networks = array(
+		'Facebook' => array(
+			'label'       => __( 'Facebook', 'alcatraz' ),
+			'id'          => 'facebook_url',
+			'description' => __( 'sdfsdfg', 'alcatraz' ),
+			'icon'        => '',
+		),
+		'Github' => array(
+			'label'       => __( 'Github', 'alcatraz' ),
+			'id'          => 'github_url',
+			'description' => __( 'sdfsdfg', 'alcatraz' ),
+			'icon'        => '',
+		),
+	);
+
+	return apply_filters( 'alcatraz_social_networks', $networks );
+}
+
 /**
  * Validate our theme options.
  *


### PR DESCRIPTION
This PR allows us to filter social icons in the footer. We created a filter for the array of social networks on the theme options page. Any additional social media links added in that array in a child theme will be now be ready for the validation process. The markup for the icons will now get generated automatically as well.   
